### PR TITLE
feat: 콘텐츠 등록, 단건 조회, 삭제 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,9 @@ gradle-app.setting
 .project
 # JDT-specific (Eclipse Java Development Tools)
 .classpath
+
+# 루트 uploads / thumbnails 폴더 전체 제외
+/uploads/
+/thumbnails/
+
+

--- a/services/api/src/main/java/com/sprint/api/service/ContentService.java
+++ b/services/api/src/main/java/com/sprint/api/service/ContentService.java
@@ -18,6 +18,9 @@ public interface ContentService {
     // 콘텐츠 삭제 (어드민)
     void deleteContent(UUID contentId);
 
+    // 콘텐츠 수정 (어드민)
+    ContentDto updateContent(UUID contentId, ContentUpdateRequest request, MultipartFile thumbnail);
+
     // 콘텐츠 목록 조회 (커서 페이지네이션)
     CursorResponseContentDto getContents(
             String typeEqual,
@@ -29,8 +32,4 @@ public interface ContentService {
             String sortBy,
             SortDirection sortDirection
     );
-
-    // 콘텐츠 수정 (어드민)
-    ContentDto updateContent(UUID contentId, ContentUpdateRequest request, MultipartFile thumbnail);
-
 }

--- a/services/api/src/main/java/com/sprint/api/service/Impl/ContentServiceImpl.java
+++ b/services/api/src/main/java/com/sprint/api/service/Impl/ContentServiceImpl.java
@@ -158,7 +158,7 @@ public class ContentServiceImpl implements ContentService {
 
     }
 
- /**
+    /**
      * 콘텐츠 수정
      */
     @Override
@@ -167,6 +167,9 @@ public class ContentServiceImpl implements ContentService {
         return null;
     }
 
+    /**
+     * 콘텐츠 목록 조회 (커서 페이지네이션)
+     */
     @Override
     public CursorResponseContentDto getContents(String typeEqual, String keywordLike, List<String> tagsIn, String cursor, UUID idAfter, int limit, String sortBy, SortDirection sortDirection) {
         return null;


### PR DESCRIPTION
## 🔖 PR 제목
[feat] 콘텐츠 등록, 단건 조회, 삭제 기능 구현 (#3)


## ✔️ Check-list
- [x] Merge 대상 브랜치 확인 (`develop`)


## 🗒️ Work Description
- Content의 기본적인 엔티티, DTO, 레포지토리, 서비스, 컨트롤러 파일을 만들었고, 등록, 단건 조회, 삭제 기능까지 구현했습니다.
- develop 브런치에서  시작 -> 뒤늦게 feature #3을 만들어버려서 코드 변경사항이 남아 있지 않습니다.
- 개발 환경: MySql은 Docker 안에 띄워서 Dbeaver를 통해 확인하도록, API서버는 로컬에서 돌아가도록 설정했습니다. 
- 오픈 API의 썸네일은 S3가 아닌 프로젝트 루트 폴더 - uploads - thumbnails 폴더 안에 저장되도록 임시 설정하였습니다.

## 📷 Screenshot
- 콘텐츠 등록
<img width="987" height="912" alt="스크린샷 2026-01-07 172115" src="https://github.com/user-attachments/assets/02fad394-aac6-4e82-a1b5-eb671246ce48" />

- 단건 조회
<img width="963" height="909" alt="스크린샷 2026-01-07 172439" src="https://github.com/user-attachments/assets/9c3ce16b-a6b2-4795-b905-a25050f000a9" />

- 콘텐츠 삭제
<img width="966" height="581" alt="스크린샷 2026-01-07 172611" src="https://github.com/user-attachments/assets/ae2c83d1-e8e1-4fbd-9bb1-96c0abcac845" />

- MySQL에서 작동하는 스크린 샷
<img width="1021" height="364" alt="스크린샷 2026-01-07 172729" src="https://github.com/user-attachments/assets/e2eeba84-6a3b-4527-8b49-58f92d9a09ca" />
<img width="987" height="446" alt="스크린샷 2026-01-07 173236" src="https://github.com/user-attachments/assets/17110dca-062b-4a64-8a0e-d8c20723227f" />

- Docker 연결 스크릿 샷
<img width="611" height="588" alt="스크린샷 2026-01-07 182801" src="https://github.com/user-attachments/assets/42757dcf-dc8b-41e5-81f8-34d3e53443ed" />






