### PR TITLE
feat: 콘텐츠 수정 API 구현

### DIFF
--- a/services/api/src/main/java/com/sprint/api/controller/ContentController.java
+++ b/services/api/src/main/java/com/sprint/api/controller/ContentController.java
@@ -41,7 +41,7 @@ public class ContentController {
 
     /**
      * 콘텐츠 목록 조회 (커서 페이지네이션)
-     * 스웨거의 typeEqual, keywordLike, tagsIn 등 쿼리 파라미터 반영
+     * - 스웨거의 typeEqual, keywordLike, tagsIn 등 쿼리 파라미터 반영
      */
     @GetMapping
     public CursorResponseContentDto getContents(

--- a/services/api/src/main/java/com/sprint/api/entity/contents/Contents.java
+++ b/services/api/src/main/java/com/sprint/api/entity/contents/Contents.java
@@ -47,4 +47,22 @@ public class Contents {
     public void addTag(ContentTag contentTag) {
         this.contentTags.add(contentTag);
     }
+
+    // 콘텐츠 제목, 설명 수정 메서드
+    public void update(String title, String description) {
+        // 들어온 값이 null이 아닐 때만 필드를 교체 (null이면 기존 값 유지)
+        if (title != null) {
+            this.title = title;
+        }
+        if (description != null) {
+            this.description = description;
+        }
+    }
+
+    // 콘텐츠 썸네일 수정 메서드
+    public void updateThumbnail(String newThumbnailUrl) {
+        if (newThumbnailUrl != null) {
+            this.thumbnailUrl = newThumbnailUrl;
+        }
+    }
 }


### PR DESCRIPTION
## 🔖 PR 제목
[feat] 콘텐츠 수정 기능 구현 (#3)


## ✔️ Check-list
- [x] Merge 대상 브랜치 확인 (`develop`)


## 🗒️ Work Description
- 업로드한 콘텐츠의 썸네일,태그를 수정할 수 있는 기능을 만들었습니다. 
- 태그 수정시 기존의 것을 clear() 한뒤 재연결을 하는 방식으로 구현하였습니다.

## 📷 Screenshot
- 수정전 DB
<img width="842" height="170" alt="수정전" src="https://github.com/user-attachments/assets/5297abdd-5522-4f7f-86d7-9c52d8e4a1a4" /> <br><br>



- 포스트맨 테스트 성공
<img width="665" height="476" alt="수정후" src="https://github.com/user-attachments/assets/def83724-2c7d-429a-8ad9-f0322c38f497" /> <br><br>



- 수정 후 DB
<img width="841" height="122" alt="수정후 (2)" src="https://github.com/user-attachments/assets/94f0f100-c931-4e51-98da-7405f6be7a47" /> <br><br>



- 썸네일도 교체된 것을 확인할 수 있음
- 파일이름 수정 전 95fa -> 수정후  dd15로 변경됨
<img width="866" height="340" alt="썸네일 수정" src="https://github.com/user-attachments/assets/e2e63739-be97-4e37-901b-12678dea92b7" />











<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Content update functionality is now available. Users can modify content titles, descriptions, thumbnails, and tags.
  * Updates apply only to specified fields; unchanged data is preserved when not explicitly updated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->