### PR TITLE
feat: Spring Security 기반 JWT 로그인 및 Refresh Token Redis 연동 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,8 @@ gradle-app.setting
 /uploads/
 /thumbnails/
 
+# 보안 정보 파일 제외
+.env
+*.env
+
 

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -17,7 +17,7 @@
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.mysema.commons/mysema-commons-lang/0.2.4/d09c8489d54251a6c22fbce804bdd4a070557317/mysema-commons-lang-0.2.4.jar" />
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.eclipse.jdt/ecj/3.26.0/4837be609a3368a0f7e7cf0dc1bdbc7fe94993de/ecj-3.26.0.jar" />
         </processorPath>
-        <module name="codeit-allplaylist.api.main" />
+        <module name="api.main" />
       </profile>
     </annotationProcessing>
   </component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/api.main.iml" filepath="$PROJECT_DIR$/.idea/modules/api.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/services/api/codeit-allplaylist.api.main.iml" filepath="$PROJECT_DIR$/.idea/modules/services/api/codeit-allplaylist.api.main.iml" />
     </modules>
   </component>

--- a/.idea/modules/api.main.iml
+++ b/.idea/modules/api.main.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../services/api/build/generated/querydsl">
+      <sourceFolder url="file://$MODULE_DIR$/../../services/api/build/generated/querydsl" isTestSource="false" generated="true" />
+    </content>
+  </component>
+</module>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,15 @@ services:
     networks:
       - app-network
 
+    # 1-2. Redis 추가
+  redis:
+    image: redis:latest
+    container_name: my-redis
+    ports:
+      - "6379:6379"
+    networks:
+      - app-network
+
   # 2. API Server (Spring Boot)
   api:
     build:
@@ -35,6 +44,7 @@ services:
     container_name: api
     depends_on:
       - mysql
+      - redis
     environment:
       SPRING_PROFILES_ACTIVE: docker
     env_file:

--- a/services/api/build.gradle
+++ b/services/api/build.gradle
@@ -49,6 +49,19 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+	// ✅ Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// ✅ JWT (토큰 생성 및 검증)
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+	// ✅ Spring Security (인증/인가 및 CSRF 기본 제공)
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+
+
 }
 
 tasks.named('test') {

--- a/services/api/src/main/java/com/sprint/api/config/CustomLoginFilter.java
+++ b/services/api/src/main/java/com/sprint/api/config/CustomLoginFilter.java
@@ -1,0 +1,42 @@
+package com.sprint.api.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+/*  커스텀 로그인 Filter
+    - 사용자가 보낸 이메일과 비밀번호를 가로채서 인증 처리
+    - application/x-www-form-urlencoded 형식에서
+    - 아이디와 비밀번호를 추출하여 인증 토큰 생성
+    -
+*/
+public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+
+        // 로그인 요청은 반드시 POST 메서드
+        if (!request.getMethod().equals("POST")) {
+            throw new AuthenticationServiceException("Authentication method not supported: " + request.getMethod());
+        }
+
+        // HttpServletRequest에서 아이디(username)와 비밀번호(password) 추출
+        // 별도의 DTO (SignInRequest) 필요 없음
+        String username = obtainUsername(request);
+        String password = obtainPassword(request);
+
+        if (username == null) username = "";
+        if (password == null) password = "";
+
+        // 유저가 입력한 아이디와 비밀번호로 인증 신청서 토큰 생성
+        UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken(username.trim(), password);
+
+        // AuthenticationManager에게 신청서 제출, DB와 검증
+        // 검증 성공시, LoginSuccessHandler로 이동하여 JWT 발급
+        return this.getAuthenticationManager().authenticate(authRequest);
+    }
+}

--- a/services/api/src/main/java/com/sprint/api/config/JwtProvider.java
+++ b/services/api/src/main/java/com/sprint/api/config/JwtProvider.java
@@ -1,0 +1,69 @@
+package com.sprint.api.config;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+/* JWT 토큰 생성하는 파일
+  - Access Token과 Refresh Token 생성 메서드 제공
+  - 비밀 키는 애플리케이션 설정 파일에서 주입받아 사용
+*/
+
+@Component
+public class JwtProvider {
+
+    private final SecretKey key;
+
+    private static final long ACCESS_TOKEN_EXPIRE = 1000L * 60 * 30; // 30분
+    private static final long REFRESH_TOKEN_EXPIRE = 1000L * 60 * 60 * 24 * 7; // 7일
+
+    // 생성자에서 설정 파일의 secret 값을 읽어와 Key 객체로 변환
+    public JwtProvider(@Value("${jwt.secret}") String secret) {
+        // 문자열 기반의 키를 HMAC SHA 알고리즘에 적합한 SecretKey 객체로 생성
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    //30분 짜리 토큰 생성 메서드
+    public String createAccessToken(String email) {
+        return createToken(email, ACCESS_TOKEN_EXPIRE);
+    }
+
+    // 7일 짜리 토큰 생성 메서드
+    public String createRefreshToken(String email) {
+        return createToken(email, REFRESH_TOKEN_EXPIRE);
+    }
+
+    // 실제 토큰 생성 메서드
+    private String createToken(String email, long expireTime) {
+        Date now = new Date();
+        return Jwts.builder()
+                .setSubject(email)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + expireTime))// 만료 시간 설정
+                .signWith(key)
+                .compact();
+    }
+
+    // 토큰에서 이메일 추출 (검증용)
+    public String getEmail(String token) {
+        return Jwts.parser().verifyWith(key).build()
+                .parseSignedClaims(token).getPayload().getSubject();
+    }
+
+    // 토큰 유효성 검사
+    public boolean validateToken(String token) {
+        try {
+            // parserBuilder() 대신 parser()를 사용하고 verifyWith(key)를 씁니다.
+            Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}
+

--- a/services/api/src/main/java/com/sprint/api/config/LoginSuccessHandler.java
+++ b/services/api/src/main/java/com/sprint/api/config/LoginSuccessHandler.java
@@ -1,0 +1,54 @@
+package com.sprint.api.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sprint.api.service.redis.RedisService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Map;
+
+
+/* 로그인 성공 핸들러 파일
+ * - 로그인이 성공하면 Redis에서
+ * - 이전 토큰을 삭제(강제 로그아웃)하고 새 토큰 발급
+ */
+
+
+@Component
+@RequiredArgsConstructor
+public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtProvider jwtProvider;
+    private final RedisService redisService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+        response.setStatus(HttpServletResponse.SC_OK); // 200 상태 코드를 명시적으로 설정
+        String email = authentication.getName();
+
+        // Redis에서 기존 리프레시 토큰 삭제
+        redisService.deleteRefreshToken(email);
+
+        // JWT 생성
+        String accessToken = jwtProvider.createAccessToken(email);
+        String refreshToken = jwtProvider.createRefreshToken(email);
+
+        // Redis에 새 리프레시 토큰 저장 (7일)
+        redisService.saveRefreshToken(email, refreshToken, 60 * 60 * 24 * 7);
+
+        // 응답 설정 (Swagger JwtDto 구조에 맞춰 JSON 반환)
+        response.setContentType("application/json;charset=UTF-8");
+        Map<String, String> tokens = Map.of(
+                "accessToken", accessToken,
+                "refreshToken", refreshToken
+        );
+
+        response.getWriter().write(objectMapper.writeValueAsString(tokens));
+    }
+}

--- a/services/api/src/main/java/com/sprint/api/config/SecurityConfig.java
+++ b/services/api/src/main/java/com/sprint/api/config/SecurityConfig.java
@@ -1,0 +1,15 @@
+package com.sprint.api.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/services/api/src/main/java/com/sprint/api/config/SecurityConfig.java
+++ b/services/api/src/main/java/com/sprint/api/config/SecurityConfig.java
@@ -1,15 +1,80 @@
 package com.sprint.api.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 
+
+/* 스프링 시큐리티 설정 클래스
+  - HTTP 보안 설정 (세션 관리, CSRF 설정, 요청 권한 설정)
+*/
 @Configuration
+@EnableWebSecurity // 스프링 시큐리티 설정 활성화
+@RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final LoginSuccessHandler loginSuccessHandler;
+    private final AuthenticationConfiguration authenticationConfiguration;
+
+    // PasswordEncoder 빈 등록
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    // CustomLoginFilter 빈 등록
+    @Bean
+    public CustomLoginFilter customLoginFilter() throws Exception {
+        CustomLoginFilter filter = new CustomLoginFilter();
+        filter.setFilterProcessesUrl("/api/auth/sign-in"); // Swagger 로그인 경로
+        filter.setAuthenticationManager(authenticationConfiguration.getAuthenticationManager());
+        filter.setAuthenticationSuccessHandler(loginSuccessHandler); // 로그인 성공 시 연결
+        return filter;
+    }
+
+    // SecurityFilterChain 빈 등록
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                // 1. JWT를 쓰므로 서버에 세션 만들지 않도록 (Stateless)
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // 2. CSRF 설정 (쿠키 저장 방식)
+                .csrf(csrf -> csrf
+                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()) // CSRF 토큰을 쿠키에 저장
+                       .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler()) // CSRF 핸들러 설정
+                )
+
+                .authorizeHttpRequests(auth -> auth
+                        //로그인과 회원가입은 아무나 접근 가능
+                        .requestMatchers(HttpMethod.POST, "/api/users", "/api/auth/sign-in").permitAll()
+                        // 나머지는 인증(로그인) 필요
+                        .anyRequest().authenticated()
+                );
+
+                // CustomLoginFilter를 씨큐리티 체인에 추가
+                http.addFilterAt(customLoginFilter(), UsernamePasswordAuthenticationFilter.class);
+                return http.build();
+
+        /* 테스트 코드
+                .csrf(csrf -> csrf.disable()) // 테스트 위해 임시허용
+                // 모든 경로에 대해 접근 허용
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()
+                );
+        http.addFilterBefore(customLoginFilter(), UsernamePasswordAuthenticationFilter.class);
+        */
     }
 }

--- a/services/api/src/main/java/com/sprint/api/service/Impl/ContentServiceImpl.java
+++ b/services/api/src/main/java/com/sprint/api/service/Impl/ContentServiceImpl.java
@@ -6,7 +6,6 @@ import com.sprint.api.entity.contents.Contents;
 import com.sprint.api.entity.contents.Tag;
 import com.sprint.api.repository.contents.ContentTagRepository;
 import com.sprint.api.repository.contents.ContentsRepository;
-import com.sprint.api.repository.contents.ContentsRepositoryCustom;
 import com.sprint.api.repository.contents.TagRepository;
 import com.sprint.api.service.contents.ContentService;
 import lombok.RequiredArgsConstructor;

--- a/services/api/src/main/java/com/sprint/api/service/redis/RedisService.java
+++ b/services/api/src/main/java/com/sprint/api/service/redis/RedisService.java
@@ -1,0 +1,34 @@
+package com.sprint.api.service.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+/*
+ 로그인 성공시 기존 토큰을 지우고 새 토큰을 저장하는 파일
+  - StringRedisTemplate을 사용하여 Redis에 문자열 데이터 CRUD
+*/
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+    // 스프링이 제공하는 Redis
+    private final StringRedisTemplate redisTemplate;
+
+    //기존 토큰 삭제 (강제 로그아웃)
+    public void deleteRefreshToken(String email) {
+        redisTemplate.delete("RT:" + email);
+    }
+
+    // 새 토큰 저장
+    public void saveRefreshToken(String email,String refreshToken, long durationSeconds) {
+        redisTemplate.opsForValue().set(
+                "RT:" + email,
+                refreshToken,
+                durationSeconds,
+                TimeUnit.SECONDS); // 만료 시간 초 단위
+    }
+}

--- a/services/api/src/main/java/com/sprint/api/service/user/CustomUserDetailsService.java
+++ b/services/api/src/main/java/com/sprint/api/service/user/CustomUserDetailsService.java
@@ -1,0 +1,33 @@
+package com.sprint.api.service.user;
+
+import com.sprint.api.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+/*
+  시큐리티와 DB 사이를 이어주는 '가이드' 역할
+  -시큐리티가 이메일 찾아줘라고 하면,
+  -DB에 가서 데이터를 꺼내온 뒤,
+  -시큐리티가 이해할 수 있는 규격(UserDetails)에 담아서 전달
+*/
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return userRepository.findByEmail(username) // emmail로 사용자 조회
+                .map(user -> org.springframework.security.core.userdetails.User.builder()
+                        .username(user.getEmail())
+                        .password(user.getPassword())
+                        .roles(user.getRole().name())
+                        .build())
+                .orElseThrow(() -> new UsernameNotFoundException("해당 이메일을 찾을 수 없습니다: " + username));
+    }
+}

--- a/services/api/src/main/java/com/sprint/api/service/user/UserService.java
+++ b/services/api/src/main/java/com/sprint/api/service/user/UserService.java
@@ -16,6 +16,11 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/*
+ * UserService 클래스
+ * - 사용자 관련 비즈니스 로직 처리
+ */
+
 @Service
 @RequiredArgsConstructor // 필수 필드 생성자 자동 생성
 public class UserService {

--- a/services/api/src/main/java/com/sprint/api/service/user/UserService.java
+++ b/services/api/src/main/java/com/sprint/api/service/user/UserService.java
@@ -12,6 +12,7 @@ import com.sprint.api.repository.user.UserRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
   private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
 
   /* ✅ 회원가입
   * -record DTO는 request.getEmail() X -> request.email() O로 꺼냄
@@ -31,11 +33,14 @@ public class UserService {
       throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
     }
 
+    // 1. 비밀번호 암호화 로직 추가
+    String encodedPassword = passwordEncoder.encode(request.password());
+
       //엔티티 생성
     User user = User.builder()
         .name(request.name())
         .email(request.email())
-        .password(request.password())
+        .password(encodedPassword)
         .build();
 
     User saved = userRepository.save(user);

--- a/services/api/src/main/resources/application-local.properties
+++ b/services/api/src/main/resources/application-local.properties
@@ -1,18 +1,22 @@
 # ----- API local, MySQL Docker -----
-# 1. ?? MySQL ?? ?? (localhost? ??)
+# 1. 로컬 MySQL 연결 설정 (localhost로 설정)
 spring.datasource.url=jdbc:mysql://localhost:3306/appdb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.username=app
 spring.datasource.password=app
 
-# 2. H2
+# 2. H2 데이터베이스 (사용 안 함)
 spring.h2.console.enabled=false
 
-# 3. JPA (MySQL)
-spring.jpa.hibernate.ddl-auto=create
+# 3. JPA 설정 (MySQL), create는 기존 테이블 삭제
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
-# 4. ??? ???? (schema.sql ?? ??? ??, ??? never)
-# MySQL? ???? ????? ?? ??? ??? ??? never? ????.
+# 4. Redis 설정
+# 도커로 띄운 Redis에 localhost:6379로 접속합니다.
+spring.data.redis.host=localhost
+spring.data.redis.port=6379
+
+# 5. SQL 초기화 설정 (schema.sql 자동 실행 방지, 항상 never)
 spring.sql.init.mode=never

--- a/services/api/src/main/resources/application.properties
+++ b/services/api/src/main/resources/application.properties
@@ -1,5 +1,8 @@
 spring.application.name=api
 spring.profiles.active=local
 
+# JWT 설정
+jwt.secret=your-very-long-and-secure-random-string-at-least-32-chars
+
 # TMDB API 토큰 (공통)
 custom.tmdb.access-token=${TMDB_ACCESS_TOKEN}

--- a/services/api/src/main/resources/application.properties
+++ b/services/api/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.application.name=api
 spring.profiles.active=local
 
 # JWT 설정
-jwt.secret=your-very-long-and-secure-random-string-at-least-32-chars
+jwt.secret=${JWT_SECRET}
 
 # TMDB API 토큰 (공통)
 custom.tmdb.access-token=${TMDB_ACCESS_TOKEN}


### PR DESCRIPTION
## 🔖 PR 제목
[feat] Spring Security 기반 JWT 로그인 및 Refresh Token Redis 연동 구현 (#10)


## ✔️ Check-list
- [x] Merge 대상 브랜치 확인 (`develop`)


## 🗒️ Work Description
- Spring Security와 JWT, Redis를 결합하여 프로젝트의 핵심 인증 및 보안 요구사항을 충족하는 인프라를 구축했습니다.

#### 1. 인증(Authentication) 로직 구현
* **JWT 기반 무상태 인증**: 로그인 성공 시 `accessToken`과 `refreshToken`을 JSON 형태로 응답하며, 서버는 세션을 유지하지 않는(Stateless) 방식으로 설계되었습니다.
* **사용자 정의 인증 필터**: `UsernamePasswordAuthenticationFilter`를 대체하는 `CustomLoginFilter`를 구현하여 `/api/auth/sign-in` 경로로 들어오는 인증 요청을 처리합니다.
* **DB 연동 검증**: `UserDetailsService`를 구현하여 DB에 저장된 실제 사용자 정보 및 암호화된 비밀번호(`BCrypt`)를 대조합니다.

#### 2. Redis를 통한 인증 정보 관리
* **Refresh Token 스토리지**: 보안 강화를 위해 `refreshToken`을 Redis(도커 컨테이너: `my-redis`)에 저장합니다.
* **중복 로그인 제어 (세션 갱신)**: 새로운 로그인 요청 시 Redis에 기존 저장된 토큰을 지우고 새 토큰으로 갱신함으로써, 기존 토큰을 무효화하도록 했습니다. (강제 로그아웃)

#### 3. CSRF 이중 보안 (요구사항 반영)
* **쿠키 기반 토큰 발급**: 로그인 성공 시 브라우저가 관리하는 `XSRF-TOKEN` 쿠키를 발급합니다.
* **헤더 검증 방식**: 모든 POST/PUT/DELETE 요청 시 헤더에 `X-XSRF-TOKEN`을 직접 실어 보내야만 요청이 허용되는 이중 잠금 구조를 적용했습니다.

---

### 📂 생성 및 수정된 주요 파일
| 파일명 | 역할 |
| :--- | :--- |
| **SecurityConfig.java** | 시큐리티 필터 체인 정의, CSRF 쿠키 저장소 및 Stateless 정책 설정 |
| **CustomLoginFilter.java** | 로그인 요청 가로채기 및 AuthenticationManager 호출 |
| **LoginSuccessHandler.java** | 인증 성공 후 JWT 생성 및 Redis 데이터 적재 처리 |
| **CustomUserDetailsService.java** | UserRepository를 통해 유저 정보를 시큐리티에 제공 |

---

### ✅ 테스트 및 검증 결과
1. **로그인 성공 (200 OK)**: 아이디/비번 일치 시 Access/Refresh 토큰 정상 발급 확인.
2. **CSRF 보안**: `XSRF-TOKEN` 쿠키 발급 확인 및 헤더 미포함 시 `403 Forbidden` 발생 검증 완료.
3. **Redis 연동**: 로그인 시 `RT:유저이메일` 키로 토큰이 저장되며, 재로그인 시 토큰 값이 최신화됨을 확인.


### 📝 주요 변경 사항 (Key Changes)



## 📷 Screenshot

### 1. 사용자 로그인 및 JWT 발급
- 로그인 성공 시 `accessToken`과 `refreshToken`이 정상적으로 발급됩니다.

<img width="469" alt="사용자로그인시" src="https://github.com/user-attachments/assets/ca638086-93df-45d2-a1be-a2cdea50ac0a" />
<img width="467" alt="시큐리티_AccessToken_발급" src="https://github.com/user-attachments/assets/9d388bd3-9331-4710-990f-16d500e99362" />

---

### 2. Redis 데이터 저장 확인
- Redis 내부에 접속하여 `RT:{이메일}` 형태의 키값과 토큰 값이 정상 저장된 것을 확인했습니다.

<img width="426" alt="key값과 토큰값" src="https://github.com/user-attachments/assets/78aa566f-4ef4-4519-a766-8558da01deb4" />

---

### 3. 동일 계정 재로그인 시 Refresh Token 갱신
- 동일 계정으로 중복 로그인 시, 기존 토큰을 대체하여 새로운 `refreshToken`이 발급되며 Redis 값이 업데이트됩니다.

<img width="421" alt="동일계정다시로그인시_refreshtoken다시발급됨" src="https://github.com/user-attachments/assets/41f45fb9-f217-41f4-b9f9-af5db73a4beb" />
<img width="435" alt="재발급시뒷부분바뀜" src="https://github.com/user-attachments/assets/cc40b90d-198d-481f-bdd2-4abe23c2203d" />

---

### 4. CSRF 보안 (XSRF-TOKEN) 적용
- 보안 요구사항에 따라 `XSRF-TOKEN` 쿠키가 발급됩니다.
- 발급된 토큰을 헤더(`X-XSRF-TOKEN`)에 포함해야만 요청이 허용되는 이중 보안 작동을 확인했습니다.

**[XSRF-TOKEN 쿠키 발급]**
<img width="467" alt="쿠키값" src="https://github.com/user-attachments/assets/e0dd634e-145c-4bc7-9ad8-56f473427d00" />

**[헤더 검증을 통한 보안 통과 확인]**
<img width="439" alt="마지막 스크린" src="https://github.com/user-attachments/assets/8d388af5-c25d-46fa-97f4-c6dbfb3c1575" />

---
### 5. TTL(Time To Live) 로직 구현
* **Redis가 직접 보관**: 7일동안 Refresh Token은 Redis가 안전하게 보관하다가, 7일 후에 자동으로 알아서 삭제됩니다.
<img width="1077" height="162" alt="스크린샷 2026-01-13 092329" src="https://github.com/user-attachments/assets/d306ffea-cef5-40aa-a6c0-ff76e1143187" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented user authentication system with JWT-based access and refresh tokens.
  * Integrated Redis for secure session and refresh token management.
  * Enabled secure login endpoint with Spring Security framework.
  * Applied password encoding to user accounts for enhanced security.

* **Chores**
  * Updated project configuration, build dependencies, and IDE setup to support authentication framework.
  * Added environment variable handling for sensitive API credentials.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->