### PR TITLE
feat: 플레이리스트 목록 조회 구현 (페이지네이션)

### DIFF
--- a/services/api/src/main/java/com/sprint/api/repository/contents/ContentsRepositoryCustomImpl.java
+++ b/services/api/src/main/java/com/sprint/api/repository/contents/ContentsRepositoryCustomImpl.java
@@ -20,7 +20,7 @@ import static com.sprint.api.entity.contents.QContents.contents;
  */
 
 @RequiredArgsConstructor
-public class ContentsRepositoryImpl implements ContentsRepositoryCustom {
+public class ContentsRepositoryCustomImpl implements ContentsRepositoryCustom {
 
     // JPA 쿼리를 자바 코드로 짤 수 있게 해주는 공장
     private final JPAQueryFactory queryFactory; // Config에서 등록한 빈이 여길로 들어옴

--- a/services/api/src/main/java/com/sprint/api/repository/playlist/PlaylistRepository.java
+++ b/services/api/src/main/java/com/sprint/api/repository/playlist/PlaylistRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
-public interface PlaylistRepository extends JpaRepository<Playlist, UUID> {
+public interface PlaylistRepository extends JpaRepository<Playlist, UUID>, PlaylistRepositoryCustom {
 }

--- a/services/api/src/main/java/com/sprint/api/repository/playlist/PlaylistRepositoryCustom.java
+++ b/services/api/src/main/java/com/sprint/api/repository/playlist/PlaylistRepositoryCustom.java
@@ -1,0 +1,20 @@
+package com.sprint.api.repository.playlist;
+
+import com.sprint.api.entity.playlists.Playlist;
+
+import java.util.List;
+import java.util.UUID;
+
+/** 플레이리스트 커스텀 레포지토리 인터페이스
+ * - 플레이리스트 조회 및 카운트 기능을 정의
+ */
+public interface PlaylistRepositoryCustom {
+
+    // 커서 기준(마지막으로 본 위치)으로 다음 페이지 가져옴
+    List<Playlist> findAllByCursor(String keywordLike, UUID ownerIdEqual, UUID subscriberIdEqual,
+                                   String cursor, UUID idAfter, int limit,
+                                   String sortDirection, String sortBy);
+
+    // 조건에 맞는 플레이리스트 개수 카운트
+    long countByConditions(String keywordLike, UUID ownerIdEqual, UUID subscriberIdEqual);
+}

--- a/services/api/src/main/java/com/sprint/api/repository/playlist/PlaylistRepositoryCustomImpl.java
+++ b/services/api/src/main/java/com/sprint/api/repository/playlist/PlaylistRepositoryCustomImpl.java
@@ -1,0 +1,98 @@
+package com.sprint.api.repository.playlist;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sprint.api.entity.playlists.Playlist;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static com.sprint.api.entity.playlists.QPlaylist.playlist;
+
+/** 플레이리스트 커스텀 레포지토리 구현체
+ * - Querydsl을 사용하여 동적 쿼리 (검색,정렬,페이징)을 처리
+ */
+
+@RequiredArgsConstructor
+public class PlaylistRepositoryCustomImpl implements PlaylistRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 커서 기반 페이징을 이용한 목록 조회
+     * @param cursor 현재 페이지의 마지막 기준값 (날짜 문자열 또는 구독자 수)
+     * @param limit 가져올 개수
+     */
+    @Override
+    public List<Playlist> findAllByCursor(String keywordLike, UUID ownerIdEqual, UUID subscriberIdEqual,
+                                          String cursor, UUID idAfter, int limit,
+                                          String sortDirection, String sortBy) {
+        return queryFactory
+                .selectFrom(playlist) // 플리에서 데이터 뽑아옴
+                .where(
+                        titleLike(keywordLike), // 검색창
+                        ownerEq(ownerIdEqual), // 특정 사용자
+                        cursorLt(cursor, sortBy)
+                )
+                .limit(limit + 1)
+                .orderBy(getOrderBy(sortBy, sortDirection),
+                        playlist.id.asc())
+                .fetch();
+    }
+
+    /**
+     * 현재 검색/필터 조건에 맞는 전체 데이터 개수 조회
+     */
+    @Override
+    public long countByConditions(String keywordLike, UUID ownerIdEqual, UUID subscriberIdEqual) {
+        Long count = queryFactory
+                .select(playlist.count())
+                .from(playlist)
+                .where(
+                        titleLike(keywordLike),
+                        ownerEq(ownerIdEqual)
+                )
+                .fetchOne();
+
+        // 결과가 null이면 0을 반환, 아니면 값을 반환
+        return count != null ? count : 0L;
+    }
+
+    // 제목 검색 조건 keyword
+    private BooleanExpression titleLike(String keyword) {
+        return (keyword != null && !keyword.isEmpty())
+                ? playlist.title.contains(keyword) : null;
+    }
+
+    // 소유자 필터
+    private BooleanExpression ownerEq(UUID ownerId) {
+        // User ID가 String이므로 toString() 변환 비교
+        return (ownerId != null)
+                ? playlist.user.id.eq(ownerId.toString()) : null;
+    }
+
+    // 커서 기준 조건 (마지막 cursor보다 작은 값 가져옴)
+    private BooleanExpression cursorLt(String cursor, String sortBy) {
+        if (cursor == null || cursor.isEmpty()) return null;
+
+        if ("subscribeCount".equals(sortBy)) {
+            return playlist.subscriberCount.lt(Long.parseLong(cursor));
+        }
+        // 기본값: 최신순(updatedAt)
+        return playlist.updatedAt.lt(LocalDateTime.parse(cursor));
+    }
+
+    // 정렬 기준 지정
+    private OrderSpecifier<?> getOrderBy(String sortBy, String direction) {
+        Order order = "ASCENDING".equalsIgnoreCase(direction) ? Order.ASC : Order.DESC;
+
+        if ("subscribeCount".equals(sortBy)) {
+            return new OrderSpecifier<>(order, playlist.subscriberCount);
+        }
+        return new OrderSpecifier<>(order, playlist.updatedAt);
+    }
+}

--- a/services/api/src/main/java/com/sprint/api/service/Impl/PlaylistServiceImpl.java
+++ b/services/api/src/main/java/com/sprint/api/service/Impl/PlaylistServiceImpl.java
@@ -259,6 +259,7 @@ public class PlaylistServiceImpl implements PlaylistService {
      * - param userId
      *
      */
+    @Override
     @Transactional
     public void deletePlaylistContent(UUID playlistId, UUID contentId, UUID userId) {
 

--- a/services/api/src/main/java/com/sprint/api/service/Impl/PlaylistServiceImpl.java
+++ b/services/api/src/main/java/com/sprint/api/service/Impl/PlaylistServiceImpl.java
@@ -154,7 +154,57 @@ public class PlaylistServiceImpl implements PlaylistService {
     public CursorResponsePlaylistDto getPlaylists(String keywordLike, UUID ownerIdEqual, UUID subscriberIdEqual,
                                                   String cursor, UUID idAfter, int limit,
                                                   String sortDirection, String sortBy) {
-        return null;
+
+        // 1. DB에서 limit + 1개를 조회 (다음 페이지 존재 여부 확인용)
+        // Playlist용 Repository Custom 메서드가 필요합니다.
+        List<Playlist> entities = playlistRepository.findAllByCursor(
+                keywordLike, ownerIdEqual, subscriberIdEqual,
+                cursor, idAfter, limit,
+                sortDirection, sortBy);
+
+        // 2. 다음 페이지(hasNext) 판단 및 실제 데이터(limit개) 절삭
+        boolean hasNext = entities.size() > limit;
+        List<Playlist> resultData = hasNext ? entities.subList(0, limit) : entities;
+
+        // 3. Entity -> DTO 변환 (기존에 만들어두신 convertToDto 사용)
+        List<PlaylistDto> data = resultData.stream()
+                .map(this::convertToDto)
+                .toList();
+
+        // 4. 다음 페이지 요청을 위한 커서(nextCursor, nextIdAfter) 생성
+        String nextCursor = null;
+        UUID nextIdAfter = null;
+
+        if (hasNext && !resultData.isEmpty()) {
+            Playlist lastItem = resultData.get(resultData.size() - 1);
+
+            // Swagger 기준 정렬 조건: updatedAt(날짜), subscribeCount(숫자)
+            nextCursor = switch (sortBy) {
+                case "subscribeCount" -> String.valueOf(lastItem.getSubscriberCount());
+                default -> lastItem.getUpdatedAt().toString(); // 최신순
+            };
+
+            nextIdAfter = lastItem.getId();
+        }
+
+        // 5. 전체 개수 조회
+        long totalCount = playlistRepository.countByConditions(keywordLike, ownerIdEqual, subscriberIdEqual);
+
+        // DTO의 enum 타입에 맞춰 변환
+        CursorResponsePlaylistDto.SortDirection direction =
+                sortDirection.equalsIgnoreCase("ASCENDING") ?
+                        CursorResponsePlaylistDto.SortDirection.ASCENDING :
+                        CursorResponsePlaylistDto.SortDirection.DESCENDING;
+
+        return new CursorResponsePlaylistDto(
+                data,
+                nextCursor,
+                nextIdAfter,
+                hasNext,
+                totalCount,
+                sortBy,
+                direction
+        );
     }
 
 

--- a/services/api/src/main/java/com/sprint/api/service/Impl/PlaylistServiceImpl.java
+++ b/services/api/src/main/java/com/sprint/api/service/Impl/PlaylistServiceImpl.java
@@ -147,7 +147,8 @@ public class PlaylistServiceImpl implements PlaylistService {
 
     /**
      * 5. 목록조회
-     * - 플레이리스트 목록을 조회하는 메서드 (미구현)
+     * - 플레이리스트 목록을 조회
+     * - 커서 기반 페이징 처리
      */
     @Override
     @Transactional(readOnly = true)
@@ -155,30 +156,29 @@ public class PlaylistServiceImpl implements PlaylistService {
                                                   String cursor, UUID idAfter, int limit,
                                                   String sortDirection, String sortBy) {
 
-        // 1. DB에서 limit + 1개를 조회 (다음 페이지 존재 여부 확인용)
-        // Playlist용 Repository Custom 메서드가 필요합니다.
+        // DB에서 limit + 1개를 조회
         List<Playlist> entities = playlistRepository.findAllByCursor(
                 keywordLike, ownerIdEqual, subscriberIdEqual,
                 cursor, idAfter, limit,
                 sortDirection, sortBy);
 
-        // 2. 다음 페이지(hasNext) 판단 및 실제 데이터(limit개) 절삭
+        // 다음 페이지(hasNext) 판단
         boolean hasNext = entities.size() > limit;
         List<Playlist> resultData = hasNext ? entities.subList(0, limit) : entities;
 
-        // 3. Entity -> DTO 변환 (기존에 만들어두신 convertToDto 사용)
+        // Entity -> DTO 변환
         List<PlaylistDto> data = resultData.stream()
                 .map(this::convertToDto)
                 .toList();
 
-        // 4. 다음 페이지 요청을 위한 커서(nextCursor, nextIdAfter) 생성
+        // 다음 페이지 요청을 위한 커서(nextCursor, nextIdAfter) 생성
         String nextCursor = null;
         UUID nextIdAfter = null;
 
         if (hasNext && !resultData.isEmpty()) {
             Playlist lastItem = resultData.get(resultData.size() - 1);
 
-            // Swagger 기준 정렬 조건: updatedAt(날짜), subscribeCount(숫자)
+            // 정렬조건: 최신순, 구독순
             nextCursor = switch (sortBy) {
                 case "subscribeCount" -> String.valueOf(lastItem.getSubscriberCount());
                 default -> lastItem.getUpdatedAt().toString(); // 최신순
@@ -187,7 +187,7 @@ public class PlaylistServiceImpl implements PlaylistService {
             nextIdAfter = lastItem.getId();
         }
 
-        // 5. 전체 개수 조회
+        // 전체 개수 조회
         long totalCount = playlistRepository.countByConditions(keywordLike, ownerIdEqual, subscriberIdEqual);
 
         // DTO의 enum 타입에 맞춰 변환
@@ -293,7 +293,7 @@ public class PlaylistServiceImpl implements PlaylistService {
             throw new CustomException(ErrorCode.ALREADY_ADDED_CONTENT);
         }
 
-        // 4. 저장 (연관관계 편의 메서드가 있다면 활용)
+        // 4. 저장
         PlaylistContents playlistContents = PlaylistContents.builder()
                 .playlist(playlist)
                 .content(content)


### PR DESCRIPTION
## 🔖 PR 제목
[feat] 플레이리스트 목록 조회 구현 (커서 기반 페이지네이션) (#18)

## ✔️ Check-list
- [x] Merge 대상 브랜치 확인 (`develop`)


## 🗒️ Work Description
- 커서 기반 페이지네이션을  써서 성능 저하 없는 목록 조회를 구현했습니다.
- Querydsl을 사용했습니다.
- 최신순, 구독순으로 정렬해서 볼 수 있게 했습니다. 
---

## 📂 변경 파일 목록 (Modified Files)
- PlaylistRepositoryCustom.java: 커서 기반 조회 및조건에 맞는 플레이리스트 개수 카운트 인터페이스 정의
- PlaylistRepositoryCustomImpl.java: Querydsl을 이용한 findAllByCursor, countByConditions 메서드 사용
- PlaylistRepository.java: Custom 인터페이스 상속 통합

## 🧪 테스트 결과 (Test Results)
- **정상 조회**: `limit` 개수만큼 정확히 데이터 반환 확인
- **페이지네이션**: 응답의 `nextCursor`를 다음 요청의 `cursor`로 넣었을 때 중복 없이 다음 페이지 데이터 로드 성공
- **필터링**: `keywordLike`를 이용한 제목 검색 및 `ownerIdEqual`을 이용한 소유자 필터 작동 확인
- **정렬**: `updatedAt` 및 `subscribeCount` 기준 내림차순(DESC) 정렬 확인

---
## 📷 Screenshot

#### 1. 플레이리스트 목록 기본 조회
<img width="470" alt="(1) 플레이리스트 목록 조회" src="https://github.com/user-attachments/assets/0ff0f7e5-2229-430e-ac44-e2b5aae704bc" />

#### 2. 커서(Cursor) 기반 페이지네이션 처리
<img width="475" alt="(2) 커서 기반 조회" src="https://github.com/user-attachments/assets/1cb11937-6bd0-48c0-b3bf-ecc5550d1194" />

- 커서 시점(updatedAt)을 기준으로  불러오는 것을 확인했습니다.

#### 3. 구독순(subscribeCount) 정렬 필터
<img width="452" alt="(3) 구독자 정렬 기준" src="https://github.com/user-attachments/assets/74f31c5f-c177-4e40-9394-d697dd0873aa" />

- 정렬 기준 변경 시 구독자 수 기준으로 전환됩니다.

#### 4. 정렬 결과 상세 데이터
<img width="739" alt="(4) 구독자 수 결과 확인" src="https://github.com/user-attachments/assets/d6f7bdb8-bd9e-4761-b97d-339a807dd6b8" />

- 구독자 수가 높은 플레이리스트가 우선 순위으로 나옵니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cursor-based pagination for playlists with keyword and owner filtering capabilities, plus sorting options by update date or subscriber count.

* **Refactor**
  * Reorganized internal repository structure for improved code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->