### PR TITLE
refact, feat: 로그인시 프론트 응답 구조 JwtDto로 변경 / 토큰 재발급 API 구현

### DIFF
--- a/services/api/src/main/java/com/sprint/api/config/CustomLoginFilter.java
+++ b/services/api/src/main/java/com/sprint/api/config/CustomLoginFilter.java
@@ -8,7 +8,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-/*  커스텀 로그인 Filter
+/**  커스텀 로그인 Filter
     - 사용자가 보낸 이메일과 비밀번호를 가로채서 인증 처리
     - application/x-www-form-urlencoded 형식에서
     - 아이디와 비밀번호를 추출하여 인증 토큰 생성

--- a/services/api/src/main/java/com/sprint/api/config/LoginSuccessHandler.java
+++ b/services/api/src/main/java/com/sprint/api/config/LoginSuccessHandler.java
@@ -2,6 +2,8 @@ package com.sprint.api.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sprint.api.dto.user.CustomUserDetailsDto;
+import com.sprint.api.dto.user.JwtDto;
+import com.sprint.api.dto.user.UserDto;
 import com.sprint.api.service.redis.RedisService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -11,7 +13,6 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationSu
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.util.Map;
 
 
 /** 로그인 성공 핸들러 클래스
@@ -38,7 +39,7 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
         // Principal에서 CustomUserDetailsDto를 꺼냄
         CustomUserDetailsDto userDetails = (CustomUserDetailsDto) authentication.getPrincipal();
-
+        var userEntity = userDetails.getUser();
         // 유저 UUID 가져옴 (토큰용)
         String userId = userDetails.getUser().getId().toString();
 
@@ -55,8 +56,7 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
         // Redis에 새 리프레시 토큰 저장 (7일)
         redisService.saveRefreshToken(email, refreshToken, 60 * 60 * 24 * 7);
 
-        // ================== [여기서부터 추가] ==================
-        // 브라우저 쿠키 저장소에 REFRESH_TOKEN을 직접 심어줍니다.
+        // 브라우저 쿠키 저장소에 REFRESH_TOKEN을 심어줌
         String cookieValue = "REFRESH_TOKEN=" + refreshToken +
                 "; Path=/" +                // 모든 경로에서 쿠키 사용 가능
                 "; HttpOnly" +            // JS에서 접근 불가 (보안)
@@ -64,14 +64,23 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
                 "; SameSite=Lax";         // 크로스 도메인 설정 (필요시)
 
         response.addHeader("Set-Cookie", cookieValue);
-        // =====================================================
 
+        // JwtDto 구조에 맞춰서 응답 생성
+        UserDto userDto = UserDto.builder()
+                .id(userId)
+                .email(email)
+                .name(userEntity.getName())
+                .role(userEntity.getRole())
+                .profileImageUrl(userEntity.getProfileImageUrl())
+                .build();
+
+        JwtDto jwtDto = JwtDto.builder()
+                .accessToken(accessToken)
+                .userDto(userDto)
+                .build();
+
+        // JSON 출력
         response.setContentType("application/json;charset=UTF-8");
-        Map<String, String> tokens = Map.of(
-                "accessToken", accessToken,
-                "refreshToken", refreshToken
-        );
-
-        response.getWriter().write(objectMapper.writeValueAsString(tokens));
+        response.getWriter().write(objectMapper.writeValueAsString(jwtDto));
     }
 }

--- a/services/api/src/main/java/com/sprint/api/config/LoginSuccessHandler.java
+++ b/services/api/src/main/java/com/sprint/api/config/LoginSuccessHandler.java
@@ -55,6 +55,17 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
         // Redis에 새 리프레시 토큰 저장 (7일)
         redisService.saveRefreshToken(email, refreshToken, 60 * 60 * 24 * 7);
 
+        // ================== [여기서부터 추가] ==================
+        // 브라우저 쿠키 저장소에 REFRESH_TOKEN을 직접 심어줍니다.
+        String cookieValue = "REFRESH_TOKEN=" + refreshToken +
+                "; Path=/" +                // 모든 경로에서 쿠키 사용 가능
+                "; HttpOnly" +            // JS에서 접근 불가 (보안)
+                "; Max-Age=" + (60 * 60 * 24 * 7) + // 7일 유지
+                "; SameSite=Lax";         // 크로스 도메인 설정 (필요시)
+
+        response.addHeader("Set-Cookie", cookieValue);
+        // =====================================================
+
         response.setContentType("application/json;charset=UTF-8");
         Map<String, String> tokens = Map.of(
                 "accessToken", accessToken,

--- a/services/api/src/main/java/com/sprint/api/config/SecurityConfig.java
+++ b/services/api/src/main/java/com/sprint/api/config/SecurityConfig.java
@@ -15,9 +15,14 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 
-/* 스프링 시큐리티 설정 클래스
+/** 스프링 시큐리티 설정 클래스
   - HTTP 보안 설정 (세션 관리, CSRF 설정, 요청 권한 설정)
 */
 @Configuration
@@ -36,6 +41,22 @@ public class SecurityConfig {
         return new BCryptPasswordEncoder();
     }
 
+    // CORS 설정 Bean (백엔드와 프론트 sse 무한로딩 해결용)
+    //@Bean
+    //public CorsConfigurationSource corsConfigurationSource() {
+    //    CorsConfiguration configuration = new CorsConfiguration();
+
+        // 프론트엔드 포트 허용
+    //    configuration.setAllowedOrigins(List.of("http://localhost:5173"));
+    //    configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+    //    configuration.setAllowedHeaders(List.of("*"));
+        // 쿠키 전송을 위해 필수 설정
+    //    configuration.setAllowCredentials(true);
+
+    //    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    //    source.registerCorsConfiguration("/**", configuration);
+    //    return source;
+    //}
 
     // CustomLoginFilter 빈 등록
     @Bean
@@ -53,29 +74,33 @@ public class SecurityConfig {
         return new JwtAuthenticationFilter(jwtProvider, userDetailsService);
     }
 
-
     // SecurityFilterChain 빈 등록
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                // 1. JWT를 쓰므로 서버에 세션 만들지 않도록 (Stateless)
+                // SSE 경로는 백엔드 기능 만들 때 다시 풀기 (주석 처리)
+                //.cors(cors -> cors.configurationSource(corsConfigurationSource()))
+
+                // JWT를 쓰므로 서버에 세션 만들지 않도록 (Stateless)
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
 
 
-                //배포시 주석풀기 (쿠키 저장 방식)
+                // 배포시 주석풀기 (쿠키 저장 방식)
                 //csrf(csrf -> csrf
                 //        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()) // CSRF 토큰을 쿠키에 저장
                 //       .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler()) // CSRF 핸들러 설정
 
 
-                // 2-1. 로컬 개발용 csrf
+                // 로컬 개발용 csrf
                 .csrf(csrf -> csrf.disable())
 
                 .authorizeHttpRequests(auth -> auth
                         // 인증 없이 접근 가능한 POST 요청들 (회원가입, 로그인, 토큰 재발급)
                         .requestMatchers(HttpMethod.POST, "/api/users", "/api/auth/sign-in", "/api/auth/refresh").permitAll()
+                        // SSE 경로 추가
+                        //.requestMatchers("/api/sse", "/api/sse/**").permitAll()
                         // 나머지는 모두 인증(로그인) 필요
                         .anyRequest().authenticated()
                 );

--- a/services/api/src/main/java/com/sprint/api/config/SecurityConfig.java
+++ b/services/api/src/main/java/com/sprint/api/config/SecurityConfig.java
@@ -74,9 +74,9 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
 
                 .authorizeHttpRequests(auth -> auth
-                        //로그인과 회원가입은 아무나 접근 가능
-                        .requestMatchers(HttpMethod.POST, "/api/users", "/api/auth/sign-in").permitAll()
-                        // 나머지는 인증(로그인) 필요
+                        // 인증 없이 접근 가능한 POST 요청들 (회원가입, 로그인, 토큰 재발급)
+                        .requestMatchers(HttpMethod.POST, "/api/users", "/api/auth/sign-in", "/api/auth/refresh").permitAll()
+                        // 나머지는 모두 인증(로그인) 필요
                         .anyRequest().authenticated()
                 );
 

--- a/services/api/src/main/java/com/sprint/api/config/WebConfig.java
+++ b/services/api/src/main/java/com/sprint/api/config/WebConfig.java
@@ -1,6 +1,7 @@
 package com.sprint.api.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -16,5 +17,18 @@ public class WebConfig implements WebMvcConfigurer {
         // 프로젝트 루트의 uploads/thumbnails 폴더를 /images/** 경로로 매핑
         registry.addResourceHandler("/images/**")
                 .addResourceLocations("file:uploads/thumbnails/");
+    }
+
+    // 2. 프론트 접속 허용
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(
+                        "http://localhost:5173", // ✅ Vite 프론트
+                        "http://localhost:3000"  // (CRA 대비용, 있어도 무방)
+                )
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
     }
 }

--- a/services/api/src/main/java/com/sprint/api/controller/AuthController.java
+++ b/services/api/src/main/java/com/sprint/api/controller/AuthController.java
@@ -1,0 +1,75 @@
+package com.sprint.api.controller;
+
+import com.sprint.api.config.JwtProvider;
+import com.sprint.api.dto.user.JwtDto;
+import com.sprint.api.dto.user.UserDto;
+import com.sprint.api.repository.user.UserRepository;
+import com.sprint.api.service.redis.RedisService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final JwtProvider jwtProvider;
+    private final RedisService redisService;
+    private final UserRepository userRepository; // 유저 확인용
+
+    @PostMapping("/refresh")
+    public ResponseEntity<?> reissueToken(
+            @CookieValue(name = "REFRESH_TOKEN", required = false) String refreshToken) {
+
+        // 1. 쿠키 검증
+        if (refreshToken == null || !jwtProvider.validateToken(refreshToken)) {
+            return ResponseEntity.status(401).body("리프레시 토큰이 유효하지 않습니다.");
+        }
+
+        // 2. 토큰에서 식별자 추출 (LoginSuccessHandler가 userId를 넣었으므로 userId가 나옴)
+        String userIdStr = jwtProvider.getEmail(refreshToken);
+        System.out.println("토큰에서 나온 ID: " + userIdStr); // <- 서버 콘솔 확인
+
+        // 3. Redis 조회를 위해 email 찾기 (핸들러가 email을 키로 저장했기 때문)
+        var user = userRepository.findById(userIdStr)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+        String email = user.getEmail();
+        System.out.println("조회된 이메일: " + email); // <- Redis Key와 일치해야 함
+
+        // 4. Redis 대조
+        String savedToken = redisService.getRefreshToken(email);
+        System.out.println("Redis 내 토큰 존재 여부: " + (savedToken != null));
+        if (savedToken == null || !savedToken.equals(refreshToken)) {
+            return ResponseEntity.status(401).body("토큰 정보가 일치하지 않습니다.");
+        }
+
+        // 5. 새 토큰 생성 (기존 로직과 동일하게 userId 주입)
+        String newAccess = jwtProvider.createAccessToken(userIdStr);
+        String newRefresh = jwtProvider.createRefreshToken(userIdStr);
+
+        // 6. Redis 및 응답 갱신
+        redisService.saveRefreshToken(email, newRefresh, 60 * 60 * 24 * 7);
+
+        // 7. JwtDto 구조에 맞춰서 응답 생성 (명세서 일치 작업)
+        UserDto userDto = UserDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .role(user.getRole()) // GNB에서 이 값을 읽습니다!
+                .profileImageUrl(user.getProfileImageUrl())
+                .build();
+
+        JwtDto jwtDto = JwtDto.builder()
+                .accessToken(newAccess)
+                .userDto(userDto)
+                .build();
+
+        return ResponseEntity.ok(jwtDto);
+    }
+}

--- a/services/api/src/main/java/com/sprint/api/controller/AuthController.java
+++ b/services/api/src/main/java/com/sprint/api/controller/AuthController.java
@@ -12,7 +12,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Map;
+/** 인증 컨트롤러
+ * - 리프레시 토큰을 이용한 액세스 토큰 재발급 처리
+ * - Redis와 JWT를 함께 사용하여 보안 강화
+ */
 
 @RestController
 @RequestMapping("/api/auth")
@@ -21,7 +24,7 @@ public class AuthController {
 
     private final JwtProvider jwtProvider;
     private final RedisService redisService;
-    private final UserRepository userRepository; // 유저 확인용
+    private final UserRepository userRepository;
 
     @PostMapping("/refresh")
     public ResponseEntity<?> reissueToken(
@@ -56,12 +59,11 @@ public class AuthController {
         // 6. Redis 및 응답 갱신
         redisService.saveRefreshToken(email, newRefresh, 60 * 60 * 24 * 7);
 
-        // 7. JwtDto 구조에 맞춰서 응답 생성 (명세서 일치 작업)
         UserDto userDto = UserDto.builder()
                 .id(user.getId())
                 .email(user.getEmail())
                 .name(user.getName())
-                .role(user.getRole()) // GNB에서 이 값을 읽습니다!
+                .role(user.getRole())
                 .profileImageUrl(user.getProfileImageUrl())
                 .build();
 

--- a/services/api/src/main/java/com/sprint/api/service/redis/RedisService.java
+++ b/services/api/src/main/java/com/sprint/api/service/redis/RedisService.java
@@ -31,4 +31,9 @@ public class RedisService {
                 durationSeconds,
                 TimeUnit.SECONDS); // 만료 시간 초 단위
     }
+
+    // Redis에서 리프레시 토큰 조회
+    public String getRefreshToken(String email) {
+        return redisTemplate.opsForValue().get("RT:" + email);
+    }
 }


### PR DESCRIPTION
## 🔖 PR 제목
[feat, refact] 로그인시 프론트 응답 구조 JwtDto로 변경 / 토큰 재발급 API 구현 (#17)

## ✔️ Check-list
- [x] Merge 대상 브랜치 확인 (`develop`)


## 🗒️ Work Description
- 로그인 성공 후 메인 페이지 진입 시 생기는 해결하기 위해 기존 토큰만 반환하던 방식에서 JwtDto 응답으로 변경했습니다.
- Swagger 명세에는 없었으나, 프론트와 연동을 해보니 `/api/auth/refresh` 가 필요해서 추가로 만들었습니다. 기존 리프레시 토큰을 서버에 던지고  새로운 액세스/리프레시 토큰 세트를 발급합니다.

## 📌 참고 사항
- 백엔드 SSE  미구현 상태에서 발생하는 무한 재연결 렉(403 Forbidden)을 방지하기 위해 관련 보안 설정을  임시로 주석 처리해놓았습니다.
- SSE 관련 코드는 백엔드 기능 개발 시점에 맞춰 다시 활성화할 예정입니다.
- 콘텐츠를 플레이리스트에 추가할때 밑으로 내려가지 않는 현상 있음 -> 플레이리스트 페이지네이션 쪽 손봐야 함





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added refresh token endpoint to reissue access tokens using stored refresh tokens.
  * Implemented refresh token persistence with cookie-based storage (7-day expiration, HttpOnly, SameSite=Lax).
  * Enhanced login response to include structured user data (id, email, name, role, profile image).

* **Chores**
  * Configured CORS to support local development environments (localhost:5173, localhost:3000).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->