### PR TITLE
refact: 플레이리스트 목록 조회시 contents 데이터 수정 및 프론트 연동 

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="RedundantScheduledForRemovalAnnotation" enabled="false" level="WARNING" enabled_by_default="false" />
+  </profile>
+</component>

--- a/services/api/src/main/java/com/sprint/api/batch/TmdbScheduler.java
+++ b/services/api/src/main/java/com/sprint/api/batch/TmdbScheduler.java
@@ -15,7 +15,8 @@ public class TmdbScheduler {
 
 
     //@Scheduled(cron = "0 0 2 * * *") // 매일 새벽 2시에 실행 (초 분 시 일 월 요일)
-    @Scheduled(cron = "0 * * * * *") // 테스트를 위해 1분마다 실행으로 해놓았음
+    //@Scheduled(cron = "0 * * * * *") // 테스트를 위해 1분마다 실행으로 해놓았음
+    @Scheduled(cron = "0 */10 * * * *") // 10분
     public void createContentsDaily() {
         log.info("=== TMDB 인기 영화 자동 등록 스케줄러 시작 ===");
         try {

--- a/services/api/src/main/java/com/sprint/api/controller/PlaylistController.java
+++ b/services/api/src/main/java/com/sprint/api/controller/PlaylistController.java
@@ -40,6 +40,22 @@ public class PlaylistController {
         CursorResponsePlaylistDto response = playlistService.getPlaylists(
                 keywordLike, ownerIdEqual, subscriberIdEqual, cursor, idAfter, limit, sortDirection, sortBy
         );
+
+        // --- 여기부터 추가 (디버깅용) ---
+        System.out.println("=========================================");
+        System.out.println("조회된 플레이리스트 개수: " + response.data().size());
+        response.data().forEach(playlist -> {
+            System.out.println("플리 제목: " + playlist.title());
+            // contents가 null인지, 아니면 비어있는지 확인하는 것이 핵심입니다.
+            if (playlist.contents() != null) {
+                System.out.println("ㄴ 포함된 콘텐츠 개수: " + playlist.contents().size());
+                playlist.contents().forEach(c -> System.out.println("   - 콘텐츠 ID: " + c.id()));
+            } else {
+                System.out.println("ㄴ [경고] contents 리스트가 null입니다!");
+            }
+        });
+        System.out.println("=========================================");
+        // --- 여기까지 추가 ---
         return ResponseEntity.ok(response);
     }
 

--- a/services/api/src/main/java/com/sprint/api/controller/PlaylistController.java
+++ b/services/api/src/main/java/com/sprint/api/controller/PlaylistController.java
@@ -40,22 +40,6 @@ public class PlaylistController {
         CursorResponsePlaylistDto response = playlistService.getPlaylists(
                 keywordLike, ownerIdEqual, subscriberIdEqual, cursor, idAfter, limit, sortDirection, sortBy
         );
-
-        // --- 여기부터 추가 (디버깅용) ---
-        System.out.println("=========================================");
-        System.out.println("조회된 플레이리스트 개수: " + response.data().size());
-        response.data().forEach(playlist -> {
-            System.out.println("플리 제목: " + playlist.title());
-            // contents가 null인지, 아니면 비어있는지 확인하는 것이 핵심입니다.
-            if (playlist.contents() != null) {
-                System.out.println("ㄴ 포함된 콘텐츠 개수: " + playlist.contents().size());
-                playlist.contents().forEach(c -> System.out.println("   - 콘텐츠 ID: " + c.id()));
-            } else {
-                System.out.println("ㄴ [경고] contents 리스트가 null입니다!");
-            }
-        });
-        System.out.println("=========================================");
-        // --- 여기까지 추가 ---
         return ResponseEntity.ok(response);
     }
 

--- a/services/api/src/main/java/com/sprint/api/service/Impl/PlaylistServiceImpl.java
+++ b/services/api/src/main/java/com/sprint/api/service/Impl/PlaylistServiceImpl.java
@@ -23,6 +23,7 @@ import com.sprint.api.service.playlists.PlaylistService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.sprint.api.dto.playlists.ContentSummary;
 
 import java.util.List;
 import java.util.UUID;
@@ -76,14 +77,41 @@ public class PlaylistServiceImpl implements PlaylistService {
      * 엔티티 -> DTO 변환, DTO에 적어도 되고, Impl에 적어도 됨
      */
     private PlaylistDto convertToDto(Playlist playlist) {
-        // UserSummary 생성
+
+        // 1. UserSummary 생성
         UserSummary owner = new UserSummary(
                 UUID.fromString(playlist.getUser().getId()),
                 playlist.getUser().getName(),
                 playlist.getUser().getProfileImageUrl()
         );
 
-        // PlaylistDto 생성
+        // 2. PlaylistContents -> ContentSummary 변환
+        List<ContentSummary> contents = playlist.getPlaylistContents().stream()
+                .map(playlistContent -> { // 변수명을 겹치지 않게 playlistContent로 변경
+                    var c = playlistContent.getContent();
+
+                    // 태그 리스트 추출
+                    List<String> tagList = (c.getContentTags() != null)
+                            ? c.getContentTags().stream()
+                            .map(ct -> ct.getTag().getTag())
+                            .toList()
+                            : List.of();
+
+                    // DTO 생성 (타입 변환 적용)
+                    return new ContentSummary(
+                            c.getId(),
+                            com.sprint.api.dto.playlists.ContentType.valueOf(c.getType().toUpperCase()), // String을 Enum으로 변환
+                            c.getTitle(),
+                            c.getDescription(),
+                            c.getThumbnailUrl(),
+                            tagList,
+                            c.getAverageRating() != null ? Double.valueOf(c.getAverageRating()) : 0.0, // Integer를 Double로 변환
+                            c.getReviewCount() != null ? c.getReviewCount() : 0
+                    );
+                })
+                .toList();
+
+        // 3. 최종 DTO 반환
         return new PlaylistDto(
                 playlist.getId(),
                 owner,
@@ -91,8 +119,8 @@ public class PlaylistServiceImpl implements PlaylistService {
                 playlist.getDescription(),
                 playlist.getUpdatedAt(),
                 playlist.getSubscriberCount(),
-                false,   //지금 로그인한 내가 이걸 구독 중인지
-                List.of() // contents (초기값)
+                false,
+                contents
         );
     }
 


### PR DESCRIPTION
## 🔖 PR 제목
[refact] 플레이리스트 목록 조회 시 콘텐츠 데이터 누락 수정 및 프론트 연동 버그 해결 (#24)

## ✔️ Check-list
- [x] Merge 대상 브랜치 확인 (`develop`)

## 🗒️ Work Description
- 기존에 List.of()로 고정되어 전달되던 contents 필드에 실제 DB에서 조회한 PlaylistContents 데이터를 매핑하도록 수정했습니다.
- 엔티티의 `String` 타입을 DTO의 `ContentType` Enum으로 변환(`valueOf`) 처리했습니다.

## 📌 참고 사항
- **프론트엔드 연동 버그 해결**
  - 백엔드에서 빈 배열(`[]`)만 응답하여 프론트엔드의 중복 체크(이미 추가된 항목 제외)가 동작하지 않던 문제를 해결했습니다.
  - 현재는 실제 데이터가 전달되어 추가된 플레이리스트가 목록에서 정상적으로 필터링됩니다.
- **향후 과제**
  - 현재 `convertToDto` 과정에서 연관 관계 엔티티를 참조하므로 N+1 문제가 발생할 가능성이 있습니다. 
  - 추후 `PlaylistRepository`에서 `fetch join`을 적용하여 쿼리 최적화를 진행할 예정입니다.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Updated content synchronization frequency to optimize system resources and reduce processing overhead.

* **Improvements**
  * Enhanced playlist content display with improved data formatting and presentation accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->