### PR TITLE
refact: 프론트 구독버튼 리팩토링

### DIFF
--- a/services/api/src/main/java/com/sprint/api/controller/PlaylistController.java
+++ b/services/api/src/main/java/com/sprint/api/controller/PlaylistController.java
@@ -29,13 +29,13 @@ public class PlaylistController {
     public ResponseEntity<CursorResponsePlaylistDto> getPlaylists(
             @RequestParam(required = false) String keywordLike,
             @RequestParam(required = false) UUID ownerIdEqual,
-            @RequestParam(required = false) UUID subscriberIdEqual,
+            @RequestParam(required = false) UUID subscriberIdEqual, // 내가 구독한 정보를 보여주기 위해
             @RequestParam(required = false) String cursor,
             @RequestParam(required = false) UUID idAfter,
             @RequestParam int limit,
             @RequestParam String sortDirection,
             @RequestParam String sortBy,
-            @AuthenticationPrincipal CustomUserDetailsDto userDetails //여기에 있던 ')' 를 지우고
+            @AuthenticationPrincipal CustomUserDetailsDto userDetails
     ) {
 
         UUID currentUserId = userDetails.getUserId();
@@ -43,13 +43,13 @@ public class PlaylistController {
         CursorResponsePlaylistDto response = playlistService.getPlaylists(
                 keywordLike,
                 ownerIdEqual,
-                subscriberIdEqual, //
+                subscriberIdEqual, // 내가 구독한 것만 남길지 말지
                 cursor,
                 idAfter,
                 limit,
                 sortDirection,
                 sortBy,
-                userDetails.getUserId() // 구독 버튼 바뀌는 인자값
+                userDetails.getUserId() // 구독중 버튼 표시를 할지 말지
         );
         return ResponseEntity.ok(response);
     }
@@ -79,10 +79,8 @@ public class PlaylistController {
     @GetMapping("/{playlistId}")
     public ResponseEntity<PlaylistDto> getPlaylist(
             @PathVariable UUID playlistId,
-            @AuthenticationPrincipal CustomUserDetailsDto userDetails // 1. 로그인 정보 추가
+            @AuthenticationPrincipal CustomUserDetailsDto userDetails
     ) {
-        // 2. 서비스 호출 시 playlistId와 현재 유저의 ID를 함께 전달
-        // (PlaylistService 인터페이스와 Impl에 파라미터를 추가한 것과 짝을 맞춰줍니다)
         PlaylistDto response = playlistService.getPlaylist(playlistId, userDetails.getUserId());
 
         return ResponseEntity.ok(response);

--- a/services/api/src/main/java/com/sprint/api/controller/PlaylistController.java
+++ b/services/api/src/main/java/com/sprint/api/controller/PlaylistController.java
@@ -43,12 +43,13 @@ public class PlaylistController {
         CursorResponsePlaylistDto response = playlistService.getPlaylists(
                 keywordLike,
                 ownerIdEqual,
-                currentUserId, // 현재 로그인한 내 ID를 넘김
+                subscriberIdEqual, //
                 cursor,
                 idAfter,
                 limit,
                 sortDirection,
-                sortBy
+                sortBy,
+                userDetails.getUserId() // 구독 버튼 바뀌는 인자값
         );
         return ResponseEntity.ok(response);
     }

--- a/services/api/src/main/java/com/sprint/api/controller/PlaylistController.java
+++ b/services/api/src/main/java/com/sprint/api/controller/PlaylistController.java
@@ -27,18 +27,28 @@ public class PlaylistController {
      */
     @GetMapping
     public ResponseEntity<CursorResponsePlaylistDto> getPlaylists(
-            @RequestParam(required = false) String keywordLike, // 검색 키워드
-            @RequestParam(required = false) UUID ownerIdEqual, // 소유자 ID
-            @RequestParam(required = false) UUID subscriberIdEqual, // 구독자 ID
-            @RequestParam(required = false) String cursor, // 커서
-            @RequestParam(required = false) UUID idAfter, // ID 이후
-            @RequestParam int limit, // 필수값, 한번에 가져올 개수
-            @RequestParam String sortDirection, // 필수값, 정렬 방향
-            @RequestParam String sortBy // 필수값, 정렬 기준
+            @RequestParam(required = false) String keywordLike,
+            @RequestParam(required = false) UUID ownerIdEqual,
+            @RequestParam(required = false) UUID subscriberIdEqual,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(required = false) UUID idAfter,
+            @RequestParam int limit,
+            @RequestParam String sortDirection,
+            @RequestParam String sortBy,
+            @AuthenticationPrincipal CustomUserDetailsDto userDetails //여기에 있던 ')' 를 지우고
     ) {
-        // 서비스 메소드명을 규칙에 따라 getPlaylists로 설정
+
+        UUID currentUserId = userDetails.getUserId();
+
         CursorResponsePlaylistDto response = playlistService.getPlaylists(
-                keywordLike, ownerIdEqual, subscriberIdEqual, cursor, idAfter, limit, sortDirection, sortBy
+                keywordLike,
+                ownerIdEqual,
+                currentUserId, // 현재 로그인한 내 ID를 넘김
+                cursor,
+                idAfter,
+                limit,
+                sortDirection,
+                sortBy
         );
         return ResponseEntity.ok(response);
     }
@@ -66,8 +76,14 @@ public class PlaylistController {
      * 플레이리스트 단건 조회
      */
     @GetMapping("/{playlistId}")
-    public ResponseEntity<PlaylistDto> getPlaylist(@PathVariable UUID playlistId) {
-        PlaylistDto response = playlistService.getPlaylist(playlistId);
+    public ResponseEntity<PlaylistDto> getPlaylist(
+            @PathVariable UUID playlistId,
+            @AuthenticationPrincipal CustomUserDetailsDto userDetails // 1. 로그인 정보 추가
+    ) {
+        // 2. 서비스 호출 시 playlistId와 현재 유저의 ID를 함께 전달
+        // (PlaylistService 인터페이스와 Impl에 파라미터를 추가한 것과 짝을 맞춰줍니다)
+        PlaylistDto response = playlistService.getPlaylist(playlistId, userDetails.getUserId());
+
         return ResponseEntity.ok(response);
     }
 

--- a/services/api/src/main/java/com/sprint/api/service/Impl/PlaylistServiceImpl.java
+++ b/services/api/src/main/java/com/sprint/api/service/Impl/PlaylistServiceImpl.java
@@ -95,10 +95,9 @@ public class PlaylistServiceImpl implements PlaylistService {
 
         // 3. PlaylistContents -> ContentSummary 변환
         List<com.sprint.api.dto.playlists.ContentSummary> contents = playlist.getPlaylistContents().stream()
-                .map(playlistContent -> { // 변수명을 playlistContent로 변경하여 충돌 회피
+                .map(playlistContent -> {
                     var c = playlistContent.getContent();
 
-                    // 태그 리스트 추출 로직 (getTags 에러 해결)
                     List<String> tagList = (c.getContentTags() != null)
                             ? c.getContentTags().stream()
                             .map(ct -> ct.getTag().getTag())
@@ -127,7 +126,7 @@ public class PlaylistServiceImpl implements PlaylistService {
                 playlist.getDescription(),
                 playlist.getUpdatedAt(),
                 playlist.getSubscriberCount(),
-                isSubscribed, // 이제 고정 false가 아닌 실제 구독 여부 전달
+                isSubscribed,
                 contents
         );
     }
@@ -143,7 +142,6 @@ public class PlaylistServiceImpl implements PlaylistService {
         Playlist playlist = playlistRepository.findById(playlistId)
                 .orElseThrow(() -> new IllegalArgumentException("플레이리스트를 찾을 수 없습니다."));
 
-        // 중요: 받아온 currentUserId를 convertToDto에 그대로 넘겨야 합니다.
         return convertToDto(playlist, currentUserId);
     }
 
@@ -284,7 +282,7 @@ public class PlaylistServiceImpl implements PlaylistService {
         playlist.increaseSubscriberCount();
 
         // 6. 실시간 알림 발송 추가
-        // 플레이리스트 주인(playlist.getUser())에게 알림을 보냅니다.
+        // 플레이리스트 주인(playlist.getUser())에게 알림 전송
         String receiverId = playlist.getUser().getId();
         String title = "새로운 구독자!";
         String content = user.getName() + "님이 당신의 [" + playlist.getTitle() + "] 플리를 구독했습니다.";

--- a/services/api/src/main/java/com/sprint/api/service/Impl/PlaylistServiceImpl.java
+++ b/services/api/src/main/java/com/sprint/api/service/Impl/PlaylistServiceImpl.java
@@ -70,14 +70,13 @@ public class PlaylistServiceImpl implements PlaylistService {
         Playlist savedPlaylist = playlistRepository.save(playlist);
 
         // DTO로 변환하여 반환
-        return convertToDto(savedPlaylist);
+        return convertToDto(savedPlaylist, currentUserId);
     }
 
     /**
      * 엔티티 -> DTO 변환, DTO에 적어도 되고, Impl에 적어도 됨
      */
-    private PlaylistDto convertToDto(Playlist playlist) {
-
+    private PlaylistDto convertToDto(Playlist playlist, UUID currentUserId) {
         // 1. UserSummary 생성
         UserSummary owner = new UserSummary(
                 UUID.fromString(playlist.getUser().getId()),
@@ -85,33 +84,42 @@ public class PlaylistServiceImpl implements PlaylistService {
                 playlist.getUser().getProfileImageUrl()
         );
 
-        // 2. PlaylistContents -> ContentSummary 변환
-        List<ContentSummary> contents = playlist.getPlaylistContents().stream()
-                .map(playlistContent -> { // 변수명을 겹치지 않게 playlistContent로 변경
+        // 2. 구독 여부 체크 (실제 로직 반영)
+        boolean isSubscribed = false;
+        if (currentUserId != null) {
+            isSubscribed = subscriptionsRepository.existsByPlaylistIdAndUserId(
+                    playlist.getId(),
+                    currentUserId.toString()
+            );
+        }
+
+        // 3. PlaylistContents -> ContentSummary 변환
+        List<com.sprint.api.dto.playlists.ContentSummary> contents = playlist.getPlaylistContents().stream()
+                .map(playlistContent -> { // 변수명을 playlistContent로 변경하여 충돌 회피
                     var c = playlistContent.getContent();
 
-                    // 태그 리스트 추출
+                    // 태그 리스트 추출 로직 (getTags 에러 해결)
                     List<String> tagList = (c.getContentTags() != null)
                             ? c.getContentTags().stream()
                             .map(ct -> ct.getTag().getTag())
                             .toList()
                             : List.of();
 
-                    // DTO 생성 (타입 변환 적용)
-                    return new ContentSummary(
+                    return new com.sprint.api.dto.playlists.ContentSummary(
                             c.getId(),
-                            com.sprint.api.dto.playlists.ContentType.valueOf(c.getType().toUpperCase()), // String을 Enum으로 변환
+                            // String을 ContentType Enum으로 변환
+                            com.sprint.api.dto.playlists.ContentType.valueOf(c.getType().toUpperCase()),
                             c.getTitle(),
                             c.getDescription(),
                             c.getThumbnailUrl(),
                             tagList,
-                            c.getAverageRating() != null ? Double.valueOf(c.getAverageRating()) : 0.0, // Integer를 Double로 변환
+                            // Integer를 Double로 변환 (null 체크 포함)
+                            c.getAverageRating() != null ? Double.valueOf(c.getAverageRating()) : 0.0,
                             c.getReviewCount() != null ? c.getReviewCount() : 0
                     );
                 })
                 .toList();
 
-        // 3. 최종 DTO 반환
         return new PlaylistDto(
                 playlist.getId(),
                 owner,
@@ -119,7 +127,7 @@ public class PlaylistServiceImpl implements PlaylistService {
                 playlist.getDescription(),
                 playlist.getUpdatedAt(),
                 playlist.getSubscriberCount(),
-                false,
+                isSubscribed, // 이제 고정 false가 아닌 실제 구독 여부 전달
                 contents
         );
     }
@@ -131,10 +139,12 @@ public class PlaylistServiceImpl implements PlaylistService {
      */
     @Override
     @Transactional(readOnly = true)
-    public PlaylistDto getPlaylist(UUID playlistId) {
+    public PlaylistDto getPlaylist(UUID playlistId, UUID currentUserId) {
         Playlist playlist = playlistRepository.findById(playlistId)
                 .orElseThrow(() -> new IllegalArgumentException("플레이리스트를 찾을 수 없습니다."));
-        return convertToDto(playlist);
+
+        // 중요: 받아온 currentUserId를 convertToDto에 그대로 넘겨야 합니다.
+        return convertToDto(playlist, currentUserId);
     }
 
     /**
@@ -154,7 +164,7 @@ public class PlaylistServiceImpl implements PlaylistService {
             throw new IllegalStateException("수정 권한이 없습니다.");
         }
         playlist.update(request.title(), request.description());
-        return convertToDto(playlist);
+        return convertToDto(playlist,currentUserId);
     }
 
     /**
@@ -185,7 +195,7 @@ public class PlaylistServiceImpl implements PlaylistService {
     @Transactional(readOnly = true)
     public CursorResponsePlaylistDto getPlaylists(String keywordLike, UUID ownerIdEqual, UUID subscriberIdEqual,
                                                   String cursor, UUID idAfter, int limit,
-                                                  String sortDirection, String sortBy) {
+                                                  String sortDirection, String sortBy,UUID currentUserId) {
 
         // DB에서 limit + 1개를 조회
         List<Playlist> entities = playlistRepository.findAllByCursor(
@@ -199,7 +209,7 @@ public class PlaylistServiceImpl implements PlaylistService {
 
         // Entity -> DTO 변환
         List<PlaylistDto> data = resultData.stream()
-                .map(this::convertToDto)
+                .map(p -> convertToDto(p,currentUserId)) // p는 리스트의 항목, 뒤에는 로그인 유저 ID 전달
                 .toList();
 
         // 다음 페이지 요청을 위한 커서(nextCursor, nextIdAfter) 생성

--- a/services/api/src/main/java/com/sprint/api/service/playlists/PlaylistService.java
+++ b/services/api/src/main/java/com/sprint/api/service/playlists/PlaylistService.java
@@ -12,11 +12,11 @@ public interface PlaylistService {
 
     PlaylistDto createPlaylist(@Valid PlaylistCreateRequest request, UUID currentUserId);
 
-    PlaylistDto getPlaylist(UUID playlistId);
+    PlaylistDto getPlaylist(UUID playlistId, UUID currentUserId);
 
     PlaylistDto updatePlaylist(UUID playlistId, PlaylistUpdateRequest request, UUID currentUserId);
 
-    CursorResponsePlaylistDto getPlaylists(String keywordLike, UUID ownerIdEqual, UUID subscriberIdEqual, String cursor, UUID idAfter, int limit, String sortDirection, String sortBy);
+    CursorResponsePlaylistDto getPlaylists(String keywordLike, UUID ownerIdEqual, UUID subscriberIdEqual, String cursor, UUID idAfter, int limit, String sortDirection, String sortBy,UUID currentUserId);
 
     void deletePlaylist(UUID playlistId, UUID currentUserId);
 


### PR DESCRIPTION
## 🔖 PR 제목
[refact] 플레이리스트 목록/단건 조회 시 구독 상태(isSubscribed) 연동 로직 리팩토링 (#28)

## ✔️ Check-list
- [x] Merge 대상 브랜치 확인 (`develop`)

## 🗒️ Work Description
- 플레이리스트 목록, 상세 조회 시, 로그인한 사용자의 실제 구독 여부를 반영하도록 했습니다.
- 검색 필터(subscriberIdEqual)와 UI 상태 표시를(currentUserId) 분리하여, 내가 만든 플레이리스트가 목록에서 사라지던 버그를 해결했습니다.

## 🔄 작업 흐름 (Work Flow)
1. **Client**: 플레이리스트 목록 또는 상세 데이터 요청 (Access Token 포함)
2. **Controller**: `@AuthenticationPrincipal`을 통해 SecurityContext에서 유저 ID 추출
3. **Service**: DB에서 전체 목록(또는 필터링된 목록)을 조회
4. **ServiceImpl)**: 조회된 각 엔티티에 대해 `currentUserId`를 대조하여 구독 여부(`true`/`false`) 판별
5. **Client**: 내 소유 플리를 포함한 전체 목록과 함께 개인화된 구독 버튼 상태 수신

---

### 💡 subscriberIdEqual vs currentUserId 차이점 정리

이번 리팩토링의 핵심은 검색 필터'와 사용자 상태 표시 파라미터를 분리한 것입니다.

| 구분 | 파라미터명 | 역할 (Role) | 비고 |
| :--- | :--- | :--- | :--- |
| **조회 필터** | `subscriberIdEqual` | "누가 구독한 목록만 보여줄까?" 결정 | DB의 `WHERE` 절에 반영 
| **상태 표시** | `currentUserId` | "목록에 뜬 플리들에 [구독중] 버튼 표시를 할까?" 결정 | DTO 변환 시 `boolean` 값 결정 (UI 상태 결정) |

#### 1. 왜 분리해야 하나요? (기존 버그 원인)
- **기존 문제**: 목록을 가져올 때 필터 조건(`subscriberIdEqual`)에 로그인한 유저 ID를 강제로 대입했습니다.
- **결과**: DB가 **"로그인 유저가 구독한 플리만 가져와"**라고 동작하여, 내가 직접 만든(구독하지 않은) 플레이리스트가 목록에서 아예 제외되는 버그가 발생했습니다.

#### 2. 리팩토링 후 동작 방식
- **조회 시**: `subscriberIdEqual`을 원래 값(전체 조회 시 `null`)으로 전달하여 내 플레이리스트를 포함한 전체 목록을 안전하게 가져옵니다.
- **가공 시**: 별도로 전달받은 `currentUserId`를 통해, 가져온 목록의 각 아이템이 "현재 내가 구독 중인 것인지"만 체크하여 하트(구독) 버튼의 색상을 결정합니다.

#### 3. 요약
- `subscriberIdEqual`: "무엇을(What)"보여줄지 결정 (필터링)
- `currentUserId`: "어떻게(How)" 보여줄지 결정 (구독 버튼 활성화 여부)


