### PR TITLE
feat: Spring Batch 모니터링을 위한 Prometheus + Grafana 연동 및 대시보드 구축

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,28 @@ services:
     networks:
       - app-network
 
+  # 6. Monitoring (Prometheus + Grafana) 로컬에만 띄우기
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
+    networks:
+      - app-network
+
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+        - prometheus
+    networks:
+      - app-network
+
+
 networks:
   app-network:
     driver: bridge

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "batch"
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets:
+          - host.docker.internal:8081 #도커 컨테이너에서 내 컴퓨터(로컬)를 의미

--- a/services/api/src/main/java/com/sprint/api/repository/contents/ContentsRepositoryCustomImpl.java
+++ b/services/api/src/main/java/com/sprint/api/repository/contents/ContentsRepositoryCustomImpl.java
@@ -30,16 +30,70 @@ public class ContentsRepositoryCustomImpl implements ContentsRepositoryCustom {
                                           String cursor, UUID idAfter, int limit,
                                           String sortBy, SortDirection sortDirection) {
 
+        // 1. 정렬 방향 결정 (기본값 DESC)
+        Order order = (sortDirection == SortDirection.ASCENDING) ? Order.ASC : Order.DESC;
+
         return queryFactory
                 .selectFrom(contents)
                 .where(
-                        typeEq(typeEqual),      // 상단 탭(영화, 스포츠 등) 필터
-                        titleLike(keywordLike),  // 검색창 키워드 필터
-                        cursorLt(cursor, sortBy) // 페이징 처리
+                        typeEq(typeEqual),
+                        titleLike(keywordLike),
+                        // 핵심: 복합 커서 조건
+                        cursorCondition(cursor, idAfter, sortBy, sortDirection)
                 )
                 .limit(limit + 1)
-                .orderBy(getOrderBy(sortBy, sortDirection), contents.id.asc())
+                // 중요: 메인 정렬 기준과 ID 정렬 기준의 방향을 반드시 일치시켜야 인덱스를 타고 중복이 없음
+                .orderBy(
+                        new OrderSpecifier<>(order, getSortPath(sortBy)),
+                        new OrderSpecifier<>(order, contents.id)
+                )
                 .fetch();
+    }
+
+    private BooleanExpression cursorCondition(String cursor, UUID idAfter, String sortBy, SortDirection direction) {
+        // 커서나 보조 커서(idAfter)가 없으면 첫 페이지로 간주
+        if (cursor == null || cursor.isEmpty() || idAfter == null) {
+            return null;
+        }
+
+        boolean isDesc = (direction == SortDirection.DESCENDING);
+
+        try {
+            // 1. 인기순 (watcherCount)
+            if ("watcherCount".equals(sortBy)) {
+                long count = Long.parseLong(cursor);
+                return isDesc
+                        ? contents.watcherCount.lt(count).or(contents.watcherCount.eq(count).and(contents.id.lt(idAfter)))
+                        : contents.watcherCount.gt(count).or(contents.watcherCount.eq(count).and(contents.id.gt(idAfter)));
+            }
+
+            // 2. 평점순 (rate 또는 averageRating) - 이미지 에러 해결 구간
+            if ("rate".equals(sortBy) || "averageRating".equals(sortBy)) {
+                // 소수점이 없는 정수형(int)이므로 Integer.parseInt 사용
+                int rating = Integer.parseInt(cursor);
+
+                return isDesc
+                        ? contents.averageRating.lt(rating).or(contents.averageRating.eq(rating).and(contents.id.lt(idAfter)))
+                        : contents.averageRating.gt(rating).or(contents.averageRating.eq(rating).and(contents.id.gt(idAfter)));
+            }
+
+            // 3. 최신순 (createdAt)
+            LocalDateTime time = LocalDateTime.parse(cursor);
+            return isDesc
+                    ? contents.createdAt.lt(time).or(contents.createdAt.eq(time).and(contents.id.lt(idAfter)))
+                    : contents.createdAt.gt(time).or(contents.createdAt.eq(time).and(contents.id.gt(idAfter)));
+
+        } catch (Exception e) {
+            // 파싱 중 에러 발생 시(데이터 포맷 불일치 등) 안전하게 첫 페이지 조회로 유도
+            return null;
+        }
+    }
+
+    // 정렬 경로 추출 헬퍼 메서드
+    private com.querydsl.core.types.dsl.ComparableExpressionBase<?> getSortPath(String sortBy) {
+        if ("watcherCount".equals(sortBy)) return contents.watcherCount;
+        if ("rate".equals(sortBy) || "averageRating".equals(sortBy)) return contents.averageRating;
+        return contents.createdAt;
     }
 
     // --- 필터 로직 (queryFactory가 쿼리를 만들 때 사용) ---
@@ -60,18 +114,22 @@ public class ContentsRepositoryCustomImpl implements ContentsRepositoryCustom {
     private BooleanExpression cursorLt(String cursor, String sortBy) {
         if (cursor == null || cursor.isEmpty()) return null;
 
-        //인기순
-        if ("watcherCount".equals(sortBy)) {
-            return contents.watcherCount.lt(Long.parseLong(cursor));
-        }
+        try {
+            if ("watcherCount".equals(sortBy)) {
+                return contents.watcherCount.lt(Long.parseLong(cursor));
+            }
 
-        //평점순
-        if ("averageRating".equals(sortBy)) {
-            return contents.averageRating.lt(Integer.parseInt(cursor));
-        }
+            if ("averageRating".equals(sortBy)) {
+                return contents.averageRating.lt(Integer.parseInt(cursor));
+            }
 
-        // 최신순
-        return contents.createdAt.lt(LocalDateTime.parse(cursor));
+            // 최신순
+            return contents.createdAt.lt(LocalDateTime.parse(cursor));
+
+        } catch (Exception e) {
+            // cursor 타입이 안 맞으면 첫 페이지로 간주
+            return null;
+        }
     }
 
     // 4. 정렬: 사용자가 UI에서 선택한 기준 적용

--- a/services/batch/build.gradle
+++ b/services/batch/build.gradle
@@ -50,8 +50,8 @@ dependencies {
 	// ✅ Micrometer
 	implementation 'io.micrometer:micrometer-core'
 
-
-
+	// ✅ Prometheus
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 

--- a/services/batch/src/main/java/com/sprint/batch/TmdbScheduler.java
+++ b/services/batch/src/main/java/com/sprint/batch/TmdbScheduler.java
@@ -14,8 +14,8 @@ public class TmdbScheduler {
     private final TmdbService tmdbService;
 
     //@Scheduled(cron = "0 0 2 * * *") // 매일 새벽 2시에 실행
-    //@Scheduled(cron = "0 * * * * *") // 1분마다 실행
-    @Scheduled(cron = "0 */10 * * * *") // 10분마다 실행
+    @Scheduled(cron = "0 * * * * *") // 1분마다 실행
+    //@Scheduled(cron = "0 */10 * * * *") // 10분마다 실행
     public void createContentsDaily() {
         log.info("=== TMDB 인기 영화 자동 등록 스케줄러 시작 ===");
         try {

--- a/services/batch/src/main/java/com/sprint/batch/config/TmdbStepConfig.java
+++ b/services/batch/src/main/java/com/sprint/batch/config/TmdbStepConfig.java
@@ -8,6 +8,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
+/** 작업 단계 설정
+ * - 배치 작업의 개별 단계를 정의하는 구성 클래스
+ * */
+
 @Configuration
 @RequiredArgsConstructor
 public class TmdbStepConfig {
@@ -19,7 +23,6 @@ public class TmdbStepConfig {
     public Step tmdbStep() {
         return new StepBuilder("tmdbStep", jobRepository)
                 .tasklet((contribution, chunkContext) -> {
-                    // TODO: tmdbService 호출
                     return org.springframework.batch.repeat.RepeatStatus.FINISHED;
                 }, transactionManager)
                 .build();

--- a/services/batch/src/main/resources/application-docker.properties
+++ b/services/batch/src/main/resources/application-docker.properties
@@ -12,5 +12,17 @@ spring.batch.jdbc.initialize-schema=never
 
 spring.batch.job.enabled=false
 
-
 custom.tmdb.access-token=${TMDB_ACCESS_TOKEN}
+
+# \u2705 Actuator endpoint \uB178\uCD9C
+management.endpoints.web.exposure.include=health,info,metrics,prometheus
+
+# \u2705 Prometheus endpoint \uD65C\uC131\uD654 (\uC774\uAC8C \uBE60\uC838 \uC788\uC5C8\uC74C)
+management.endpoint.prometheus.enabled=true
+
+# \u2705 actuator \uAE30\uBCF8 \uACBD\uB85C
+management.endpoints.web.base-path=/actuator
+
+# \u2705 Spring Batch \uBA54\uD2B8\uB9AD
+management.metrics.enable.spring.batch=true
+

--- a/services/batch/src/main/resources/application-local.properties
+++ b/services/batch/src/main/resources/application-local.properties
@@ -8,3 +8,7 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 
 custom.tmdb.access-token=${TMDB_ACCESS_TOKEN}
+
+# \u2705 Actuator endpoint \uB178\uCD9C
+management.endpoints.web.exposure.include=health,info,metrics,prometheus
+management.endpoint.prometheus.enabled=true

--- a/services/batch/src/main/resources/application.properties
+++ b/services/batch/src/main/resources/application.properties
@@ -1,7 +1,4 @@
 spring.application.name=batch
 spring.profiles.active=docker
 
-# \u2705 Actuator \uB178\uCD9C \uC124\uC815
-management.endpoints.web.exposure.include=health,info,metrics
-management.endpoint.health.show-details=always
 


### PR DESCRIPTION
## 🔖 PR 제목  
[feat]Spring Batch 모니터링을 위한 Prometheus + Grafana 연동 및 대시보드 구축 (#37)

---

## ✔️ Check-list  
- [x] Merge 대상 브랜치 확인 (`develop`)

---

## 🗒️ Work Description  
- Spring Batch 실행 상태/성능을 운영자가 실시간으로 확인할 수 있도록 Prometheus + Grafana 기반 모니터링 환경을 구축했습니다.  
- Batch 서버에서 Actuator `/actuator/prometheus` 엔드포인트를 노출하여 메트릭을 제공하고, Prometheus가 이를 수집하도록 설정했습니다.  
- Grafana에서 Prometheus를 Data Source로 연결한 뒤, 배치 운영에 필요한 핵심 지표를 패널로 고정해 대시보드로 구성했습니다.  

---

## 🔄 전체적인 흐름  
1. Batch 서버에서 Micrometer + Actuator 기반 메트릭 노출 (`/actuator/prometheus`)  
2. Prometheus가 Batch 메트릭을 주기적으로 수집
3. Grafana가 Prometheus를 데이터 소스로 조회  
4. 대시보드에서 배치 실행 횟수/실행시간/JVM/DB 커넥션 등 운영 지표를 시각화  

---

## 📂 생성 및 수정된 주요 파일  
- `docker-compose.yml`  
  - Prometheus / Grafana 컨테이너 서비스 추가 및 포트/네트워크 구성  
- `monitoring/prometheus.yml`  
  - Batch 서버의 `/actuator/prometheus` 메트릭 수집 대상(job/target) 설정  
- `ContentsRepositoryCustomImpl`
  - 콘텐츠 중복 노출 및 무한 로딩 에러 해결

---

## 📷 Screenshot  

### (1) actuator에 prometheus 확인  
- `/actuator` 엔드포인트에서 `prometheus` 링크가 노출되는 것을 확인해 메트릭 수집 준비 상태를 검증했습니다.  
<img width="676" height="732" alt="(1)actuator에prometheus확인" src="https://github.com/user-attachments/assets/45a03428-f10b-494f-a220-21adfbce591f" />

### (2) 앱 가동/준비 시간 정상  
- `application_ready_time_seconds` 등 앱 기동/준비 시간 관련 메트릭이 정상 출력됨을 확인했습니다.  
<img width="955" height="419" alt="(2)앱가동,준비시간정상" src="https://github.com/user-attachments/assets/f0e52157-3ce7-4a2e-b81d-b123635473b8" />

### (3) DB 연결 정상  
- HikariCP 관련 메트릭을 통해 DB 커넥션 풀 지표가 수집되는 것을 확인했습니다.  
<img width="960" height="700" alt="(3)DB연결정상" src="https://github.com/user-attachments/assets/c72aa2b5-32fe-4c21-bd90-dcf6f59d0126" />

### (3) JVM 관련 정상 (Grafana JVM 대시보드 활용 가능)  
- JVM 메모리/스레드/GC 관련 메트릭이 출력되어 Grafana JVM 대시보드 구성 가능함을 확인했습니다.  
<img width="875" height="1025" alt="(3)JVM 관련정상_JVM대시보드쓸수있음그라파나에서" src="https://github.com/user-attachments/assets/be97983c-d5bb-4c8c-954f-01e29460163d" />

### (4) 배치 핵심 지표 확인 (count / sum / max)  
- 배치 실행 횟수 및 실행 시간(총합/최대값) 등 운영자가 확인하고 싶은 배치 지표가 수집되는 것을 확인했습니다.  
<img width="958" height="567" alt="(4)내배치18번_6 8초_max_0 23초_운영자가보고싶어하는배치지표그자체" src="https://github.com/user-attachments/assets/cf43c2b7-99b3-47df-9aff-c8317cb483da" />

### (5) Prometheus 서버 + Grafana 서버 기동  
- Prometheus(9090) / Grafana(3000) 컨테이너를 로컬에서 실행하여 모니터링 스택을 구성했습니다.  
<img width="1216" height="105" alt="(5)Prometheus 서버와 Grafana서버 띄우기" src="https://github.com/user-attachments/assets/4c1a5b8a-3b43-4439-ad96-180ea06e7543" />

### (6) Prometheus 정상 수집 상태 확인  
- Prometheus Targets 화면에서 마지막 수집 시간 및 scrape 응답 상태가 정상임을 확인했습니다.  
<img width="1013" height="602" alt="(6)프로메테우스정상작동_마지막수집언제_응답속도몇등" src="https://github.com/user-attachments/assets/1db56208-6fa0-40c6-a2e8-3915342778bb" />

### (7) GC/메모리 사용 패턴 확인  
- 특정 시점의 GC 발생과 이후 메모리 사용량 증가 흐름을 그래프로 확인하여 JVM 상태를 모니터링할 수 있음을 검증했습니다.  
<img width="1013" height="923" alt="(7)04,34분에 서버가 메모리 청소(GC)를 한 번 시원하게 했고, 그 이후로 04,41분까지 다시 170MB에서 220MB까지 차근차근 메모리를 사용하며 잘 돌아가고 있다" src="https://github.com/user-attachments/assets/ffe5938e-e889-4e60-bad8-53a3effa12af" />

### (8) 트래픽/요청 증가 추이 확인  
- 특정 시점에 요청이 증가한 흔적을 그래프로 확인하여 애플리케이션 부하 변화를 관측 가능함을 검증했습니다.  
<img width="1011" height="822" alt="(8)04,36분쯤에 평소보다 요청이 좀 더 들어왔다는것을 그래프로확인가능" src="https://github.com/user-attachments/assets/fd059cbf-aaf2-4c60-9229-086386b0ee89" />

### (9) Grafana에서 배치 누적 실행 횟수 확인  
- `tasks_scheduled_execution_seconds_count` 기반으로 배치가 누적 몇 번 실행됐는지 시각화했습니다.  
<img width="886" height="977" alt="(9)그라파나홈페이지_배치지금까지202번실행된것을확인" src="https://github.com/user-attachments/assets/cbd28c8e-5f5b-4f4d-8238-57565ffeccab" />

### (10) Grafana에서 최근 5분 평균 실행 시간 확인  
- `rate(tasks_scheduled_execution_seconds_sum[5m])` 기반으로 최근 5분 배치 평균 실행 시간을 시각화했습니다.  
<img width="936" height="995" alt="(10)그라파나홈페이지_최근5분동안배치1회평균실행시간초_배치한번에0,23초" src="https://github.com/user-attachments/assets/5c42fbdc-0131-42ec-a885-26d9ce13af89" />

### (11) 대시보드에서 핵심 지표 통합 확인  
- 실행 횟수/실행 시간 등 핵심 배치 지표를 하나의 대시보드로 고정 구성하여 운영 화면 형태로 정리했습니다.  
<img width="907" height="752" alt="(11)대쉬보드에서한번에모아볼수있음" src="https://github.com/user-attachments/assets/5dca3b60-f79f-473e-b4ad-4dd43117fbf3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Prometheus and Grafana for system monitoring and performance visualization
  * Enabled Actuator endpoints to expose real-time application metrics

* **Improvements**
  * Optimized content pagination with advanced cursor-based sorting for better browsing
  * Increased batch scheduler frequency for more frequent data synchronization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->